### PR TITLE
Add a multiprocess to write_recon and add new diff mode to eventdisplay

### DIFF
--- a/EventDisplay/eventdisplay/ped.py
+++ b/EventDisplay/eventdisplay/ped.py
@@ -938,48 +938,57 @@ class Application(Camera, Piezo, SlowDAQ, LogViewer, Configuration, Analysis, Th
         self.bubble_events = None
         self.bubble_t0 = {}
 
-        if not self.reco_directory or not self.run:
-            self.logger.error('reco directory not set in config, reco data will be disabled')
+        # This is a temporary hack for loading in custom reco files
+        # Eventdisplay will look in the custom path first
+        # If no reco.sbc is found there it will look in the default path.
+        custom = os.environ.get('CUSTOM_RECO_PATH')
+        roots = [r for r in (os.path.expanduser(custom) if custom else None, self.reco_directory) if r]
+
+        def find_recon(name):  # first <root>/dev-output/<run>/<name> that exists
+            for root in roots:
+                candidate = os.path.join(root, 'dev-output', self.run, name)
+                if os.path.isfile(candidate):
+                    return candidate
+            return None
+
+        if not roots or not self.run:
+            self.logger.error('no reco dir (config or CUSTOM_RECO_PATH), reco data will be disabled')
             self.reco_availability_label.config(text='Not Loaded')
             self.toggle_reco_widgets(state=tk.DISABLED)
             for _, text, _ in self.display_vars:
                 text.set('N/A')
             return
 
-        path = os.path.join(self.reco_directory, 'dev-output', self.run, 'reco.sbc')
-        if not os.path.isfile(path):
-            self.logger.error('cannot find {}, reco data will be disabled'.format(path))
-            self.reco_availability_label.config(text='Not Loaded')
-            self.toggle_reco_widgets(state=tk.DISABLED)
-            for _, text, _ in self.display_vars:
-                text.set('N/A')
-            return
-
-        self.logger.info('using reco data from {}'.format(path))
-
-        events = Streamer(path).data
+        # reco.sbc is optional and no longer gates the bubble overlay loaded below
+        path = find_recon('reco.sbc')
+        events = Streamer(path).data if path else []
         if len(events) == 0:
-            self.logger.error('no reco events found in {}'.format(path))
-            return
+            self.logger.error('no reco.sbc found under {}, reco data disabled'.format(roots))
+            self.reco_availability_label.config(text='Not Loaded')
+            self.toggle_reco_widgets(state=tk.DISABLED)
+            for _, text, _ in self.display_vars:
+                text.set('N/A')
+        else:
+            self.logger.info('using reco data from {}'.format(path))
+            # convert coords_3D array field into scalar X, Y, Z for widgets
+            new_dtype = np.dtype([('X', '<f8'), ('Y', '<f8'), ('Z', '<f8'), ('ev', '<i4')])
+            coordinates = np.zeros(len(events), dtype=new_dtype)
+            coordinates['X'] = events['coords_3D'][:, 0]
+            coordinates['Y'] = events['coords_3D'][:, 1]
+            coordinates['Z'] = events['coords_3D'][:, 2]
+            coordinates['ev'] = events['ev']
+            self.reco_events = coordinates
+            print('reco loaded: {} rows, fields: {}'.format(len(self.reco_events), self.reco_events.dtype.names))
+            self.add_display_var_combobox['values'] = sorted(self.reco_events.dtype.names)
 
-        # convert coords_3D array field into scalar X, Y, Z for widgets
-        new_dtype = np.dtype([('X', '<f8'), ('Y', '<f8'), ('Z', '<f8'), ('ev', '<i4')])
-        coordinates = np.zeros(len(events), dtype=new_dtype)
-        coordinates['X'] = events['coords_3D'][:, 0]
-        coordinates['Y'] = events['coords_3D'][:, 1]
-        coordinates['Z'] = events['coords_3D'][:, 2]
-        coordinates['ev'] = events['ev']
-        self.reco_events = coordinates
-        print('reco loaded: {} rows, fields: {}'.format(len(self.reco_events), self.reco_events.dtype.names))
-        self.add_display_var_combobox['values'] = sorted(self.reco_events.dtype.names)
-
-        bubble_path = os.path.join(self.reco_directory, 'dev-output', self.run, 'bubble.sbc')
-        if os.path.isfile(bubble_path):
+        # bubble.sbc loads independently of reco.sbc (overlay works with bubble alone)
+        bubble_path = find_recon('bubble.sbc')
+        if bubble_path is not None:
             self.bubble_events = Streamer(bubble_path).data
             print("bubble loaded: {} rows, fields: {}".format(len(self.bubble_events), self.bubble_events.dtype.names))
             self.compute_bubble_t0()
         else:
-            self.logger.error('cannot find {}'.format(bubble_path))
+            self.logger.error('no bubble.sbc found under {}'.format(roots))
 
     def compute_bubble_t0(self):
         # Bubble t0 per event is earliest bubble frame across cameras
@@ -1284,6 +1293,13 @@ class Application(Camera, Piezo, SlowDAQ, LogViewer, Configuration, Analysis, Th
             value='first',
             command=self.update_images)
         self.diff_first_radio.grid(row=1, column=2, sticky='W')
+
+        self.diff_bubble_radio = tk.Radiobutton(self.image_options_frame,
+            text='bubble diff',
+            variable=self.diff_mode_var,
+            value='bubble',
+            command=self.update_images)
+        self.diff_bubble_radio.grid(row=1, column=3, sticky='W')
 
         self.diff_threshold_label = tk.Label(self.image_options_frame, text='threshold:')
         self.diff_threshold_label.grid(row=2, column=0, sticky='W')

--- a/EventDisplay/eventdisplay/tabs/camera.py
+++ b/EventDisplay/eventdisplay/tabs/camera.py
@@ -3,6 +3,37 @@ import subprocess, os, platform
 import tkinter as tk
 from PIL import Image, ImageChops, ImageOps, ImageTk
 import cv2
+import numpy as np
+from skimage.draw import disk
+
+
+# don't recalculate the mask for ever frame in the camera
+_BUBBLE_MASK_CACHE = {}
+
+# direct copy of ana/BubbleFinder's masks
+def _bubble_region_mask(cam, shape):
+    key = (cam, shape)
+    mask = _BUBBLE_MASK_CACHE.get(key)
+    if mask is None:
+        imShape = shape
+        if cam == 1:
+            circy, circx = disk((375, 595), 300, shape=imShape)
+            coord_mask = 1.9 * circx - 1200 < circy
+            mask_circx = circx[coord_mask]
+            mask_circy = circy[coord_mask]
+        elif cam == 2:
+            mask_circy, mask_circx = disk((420, 670), 300, shape=imShape)
+        elif cam == 3:
+            mask_circy, mask_circx = disk((440, 690), 300, shape=imShape)
+        else:
+            mask = np.ones(imShape, dtype=bool)
+            _BUBBLE_MASK_CACHE[key] = mask
+            return mask
+        # paint the (mask_circy, mask_circx) indices into the boolean mask this returns
+        mask = np.zeros(imShape, dtype=bool)
+        mask[mask_circy, mask_circx] = True
+        _BUBBLE_MASK_CACHE[key] = mask
+    return mask
 
 
 class Camera(tk.Frame):
@@ -67,6 +98,44 @@ class Camera(tk.Frame):
 
         return ImageOps.autocontrast(diff), ref_frame
 
+    def _load_native_gray(self, cam, frame):
+        """Raw frame as a float32 grayscale array (channel mean), pre-rotation --
+        BubbleFinder's region masks are defined in this raw orientation."""
+        path = self.get_image_path(cam, frame)
+        src = self.zipped_event.open(path) if self.zip_flag else path
+        return np.asarray(Image.open(src).convert('RGB'), dtype=np.float32).mean(axis=2)
+
+    def _apply_display_geometry(self, image, canvas):
+        """The same rotate/resize/crop load_image applies, so a natively-computed
+        diff lines up with the displayed frame and the crosshairs."""
+        if self.image_orientation == '90':
+            image = image.transpose(Image.ROTATE_90)
+        elif self.image_orientation == '180':
+            image = image.transpose(Image.ROTATE_180)
+        elif self.image_orientation == '270':
+            image = image.transpose(Image.ROTATE_270)
+        image = image.resize((int(canvas.image_width), int(canvas.image_height)),
+                             self.antialias_checkbutton_var.get())
+        return image.crop((canvas.crop_left, canvas.crop_bottom, canvas.crop_right, canvas.crop_top))
+
+    def get_bubble_diff(self, canvas, fallback):
+        """Diff that mirrors what BubbleFinder's CHT votes on: previous-frame abs
+        diff, a noise_thresh floor, and the camera's hard bubble-region mask.
+        Recipe + masks mirror ana/BubbleFinder.py FindBubbles funciton"""
+        noise_thresh = self.diff_threshold_var.get()
+        cur = int(self.frame)
+        ref = cur - 1 if cur > int(self.first_frame) else int(self.first_frame)
+        try:
+            diff = np.abs(self._load_native_gray(canvas.cam, cur)
+                          - self._load_native_gray(canvas.cam, ref))
+        except (FileNotFoundError, KeyError, OSError):
+            self.logger.info('bubble diff: missing frame for cam {}'.format(canvas.cam))
+            return fallback, ref
+        diff[diff < noise_thresh] = 0
+        diff[~_bubble_region_mask(canvas.cam + 1, diff.shape)] = 0  # canvas.cam 0-idx; BF cam 1-idx
+        image = self._apply_display_geometry(Image.fromarray(diff.astype(np.uint8), mode='L'), canvas)
+        return ImageOps.autocontrast(image), ref
+
     def update_images(self):
         error = ' '
         for canvas in self.canvases:
@@ -74,9 +143,13 @@ class Camera(tk.Frame):
             image = self.load_image(path, canvas)
 
             zoom = '{:.1f}'.format(canvas.image_width / self.native_image_width)
-            if self.diff_mode_var.get() != 'off':
+            mode = self.diff_mode_var.get()
+            if mode == 'bubble':
+                image, ref_frame = self.get_bubble_diff(canvas, image)
+                template = 'frame: {} zoom: {}x (bub-diff wrt {})              {}/{}'
+                bottom_text = template.format(self.frame, zoom, ref_frame, self.run, self.event)
+            elif mode != 'off':
                 image, ref_frame = self.get_image_diff(image, canvas)
-
                 template = 'frame: {} zoom: {}x (diff wrt {})                  {}/{}'
                 bottom_text = template.format(self.frame, zoom, ref_frame, self.run, self.event)
             else:

--- a/ana/BubbleValidator/write_recon.py
+++ b/ana/BubbleValidator/write_recon.py
@@ -9,13 +9,17 @@ see the effect on one run
     python write_recon.py [run] [out_root] [unpacked_root]
 
 Pass 'all' as the run to regenerate every unique run in the handscan CSV. This is
-the long job, usually run on the grid after a single run has been sanity-checked:
+the long job; runs are independent so it fans out across CPU cores (--nprocs):
 
-    python write_recon.py all [out_root] [unpacked_root] [csv_path]
+    python write_recon.py all [out_root] [unpacked_root] [--nprocs N]
+
+Run with -h/--help for all options.
 """
+import argparse
 import csv
 import os
 import sys
+from multiprocessing import Pool
 
 # Weird workaround
 _GRID = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "grid_jobs"))
@@ -26,13 +30,14 @@ from EventDealer import ProcessSingleRun
 
 HERE = os.path.dirname(os.path.abspath(__file__))  # write recon here, never into shared /exp data
 
+
 def write_recon(run, out_root, unpacked_root):
     """Run BubbleFinder over `run` -> <out_root>/<run>/bubble.sbc, then return that path."""
     # this is a dev wrapper that deletes/rewrites bubble.sbc. never let it touch shared /exp recon
-    if os.path.realpath(out_root).startswith("/exp/"):  # realpath resolves symlinks into /exp
+    if os.path.realpath(out_root).startswith("/exp/"):
         raise SystemExit(f"refusing to write recon under shared /exp: {out_root}")
     out_dir = os.path.join(out_root, run)
-    os.makedirs(out_dir, exist_ok=True)  # ProcessSingleRun only mkdirs the leaf, not parents
+    os.makedirs(out_dir, exist_ok=True)
     bubble_sbc = os.path.join(out_dir, "bubble.sbc")
     if os.path.exists(bubble_sbc):
         os.remove(bubble_sbc)  # the sbc Writer appends; a stale file would double the rows
@@ -41,47 +46,96 @@ def write_recon(run, out_root, unpacked_root):
         rundir=os.path.join(unpacked_root, run),
         recondir=out_dir,
         process_list=["bubble"],
+        # maxevt=3,  # uncomment to cap events per run for a quick dev iteration
     )
 
     print(f"\nwrote {bubble_sbc}")
     return bubble_sbc
 
 
-def write_recon_all(out_root, unpacked_root, csv_path):
+def _run_one(task):
+    """Pool worker: process one run. Returns (run, ok, err_or_None).
+
+    Each run owns its own <out_root>/<run>/bubble.sbc, so workers never share the appending
+    sbc Writer -- that's why run-level is the safe unit of parallelism."""
+    run, out_root, unpacked_root = task
+    try:
+        write_recon(run, out_root, unpacked_root)
+        return run, True, None
+    except Exception as exc:  # one bad run shouldn't kill the whole batch
+        # drop any partial bubble.sbc so validate.py won't trust a half-written file
+        partial = os.path.join(out_root, run, "bubble.sbc")
+        if os.path.exists(partial):
+            os.remove(partial)
+        return run, False, str(exc)
+
+
+def write_recon_all(out_root, unpacked_root, csv_path, nprocs=None):
     """Regenerate bubble.sbc for every unique run in the handscan CSV. Long job.
 
-    One run failing (missing images, bad data) logs and is skipped so the batch
-    finishes; failures are summarized at the end.
+    Runs are independent, so they fan out across a multiprocessing.Pool. Default
+    uses all cores, capped at the run count. nprocs=1 forces the 1 process. One run
+    failing (missing images, bad data) logs and is skipped so the batch finishes.
     """
+    run_events = {}
     with open(csv_path) as fh:
-        runs = sorted({row["run"] for row in csv.DictReader(fh)})
+        for row in csv.DictReader(fh):
+            run_events.setdefault(row["run"], set()).add(int(row["ev"]))
+    # start the runs with the most handscan events before the small ones,
+    # so the heaviest job isn't left running alone at the end on a single core.
+    runs = sorted(run_events, key=lambda r: len(run_events[r]), reverse=True)
+    tasks = [(r, out_root, unpacked_root) for r in runs]
 
-    print(f"{len(runs)} runs from {csv_path}\n")
+    if nprocs is None:
+        nprocs = min(len(runs), os.cpu_count() or 1)
+    nprocs = max(1, min(nprocs, len(runs)))
+
+    print(f"{len(runs)} runs from {csv_path} -- {nprocs} worker(s)\n")
     failed = []
-    for i, run in enumerate(runs, 1):
-        print(f"[{i}/{len(runs)}] {run}")
-        try:
-            write_recon(run, out_root, unpacked_root)
-        except Exception as exc:  # one bad run shouldn't kill the whole batch
-            print(f"[fail] {run}: {exc}")
+
+    def _report(i, run, ok, err):
+        if ok:
+            print(f"[{i}/{len(runs)}] {run} ok")
+        else:
+            print(f"[{i}/{len(runs)}] [fail] {run}: {err}")
             failed.append(run)
-            # drop any partial bubble.sbc so validate.py won't trust a half-written file
-            partial = os.path.join(out_root, run, "bubble.sbc")
-            if os.path.exists(partial):
-                os.remove(partial)
+
+    if nprocs == 1:
+        for i, task in enumerate(tasks, 1):
+            _report(i, *_run_one(task))
+    else:
+        # imap_unordered: report each run as it finishes rather than waiting for the slowest.
+        with Pool(processes=nprocs) as pool:
+            for i, (run, ok, err) in enumerate(pool.imap_unordered(_run_one, tasks), 1):
+                _report(i, run, ok, err)
 
     print(f"\ndone: {len(runs) - len(failed)}/{len(runs)} ok")
     if failed:
         print(f"failed: {', '.join(failed)}")
 
 
-if __name__ == "__main__":
+def _parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Regenerate a dev bubble.sbc for one run, or 'all' runs in the handscan CSV.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     # writes recon next to the CSVs (never into shared /exp); raw images read from unpacked
-    run = sys.argv[1] if len(sys.argv) > 1 else "20260213_4"
-    out_root = sys.argv[2] if len(sys.argv) > 2 else os.path.join(HERE, "dev-output")
-    unpacked_root = sys.argv[3] if len(sys.argv) > 3 else "/exp/e961/data/SBC-25-unpacked"
-    if run == "all":
-        csv_path = sys.argv[4] if len(sys.argv) > 4 else os.path.join(HERE, "all_handscans.csv")
-        write_recon_all(out_root, unpacked_root, csv_path)
+    p.add_argument("run", nargs="?", default="20260213_4",
+                   help="run name to reprocess, or 'all' for every run in the CSV")
+    p.add_argument("out_root", nargs="?", default=os.path.join(HERE, "dev-output"),
+                   help="recon output root (refused under shared /exp)")
+    p.add_argument("unpacked_root", nargs="?", default="/exp/e961/data/SBC-25-unpacked",
+                   help="root of the unpacked raw images")
+    p.add_argument("--csv", default=os.path.join(HERE, "all_handscans.csv"),
+                   help="handscan CSV providing the run list for 'all'")
+    p.add_argument("--nprocs", type=int, default=None,
+                   help="parallel workers for 'all' (default: all cores, capped at run count)")
+    return p.parse_args(argv)
+
+
+if __name__ == "__main__":
+    a = _parse_args()
+    if a.run == "all":
+        write_recon_all(a.out_root, a.unpacked_root, a.csv, nprocs=a.nprocs)
     else:
-        write_recon(run, out_root, unpacked_root)
+        write_recon(a.run, a.out_root, a.unpacked_root)


### PR DESCRIPTION
## `write_recon.py`
Now supports multi process executions.  Previously it would run serially and take `processing time x number of runs` but now takes as long as the longest run because they run in parallel.

## Event display
We added the ability to pass in a custom recon path via a env var `CUSTOM_RECO_PATH`.  This is a bit of a hack and is better as a configuration var but for now this works.

We also added a new diff option.  Handscanners and analysis devs can work view the diff as the CHT BubbleFinder sees the diff.  This should help find features that are getting obscured in the diffing process of the Bubble finder.  The diff includes the mask and diff settings that BubbleFinder uses